### PR TITLE
Fix permission error and allow interactive mode in entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ RUN useradd --system folding && \
     apt-get autoremove --yes && \
     rm -rf /var/lib/apt/lists/*
 
-COPY entrypoint.sh /opt/fahclient
+COPY --chown=folding:folding entrypoint.sh /opt/fahclient
+
+RUN chmod +x /opt/fahclient/entrypoint.sh
 
 ENV USER "Anonymous"
 ENV TEAM "0"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ set -e
 if [ "${1}" ]
 then
   exec "$@"
-# otherwise we attempt to run boinc.
+# otherwise we attempt to run fahclient.
 else
   /opt/fahclient/FAHClient \
       --user="${USER}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
+set -e
 
-/opt/fahclient/FAHClient \
-    --user=${USER} \
-    --team=${TEAM} \
-    --passkey=${PASSKEY} \
-    --gpu=${ENABLE_GPU} \
-    --smp=${ENABLE_SMP} \
-    --power=full \
-    --gui-enabled=false \
-    ${@}
+# if a command was specified, we run that command. E.g. helpful when we do
+# docker run -it <container> /bin/bash
+if [ "${1}" ]
+then
+  exec "$@"
+# otherwise we attempt to run boinc.
+else
+  /opt/fahclient/FAHClient \
+      --user="${USER}" \
+      --team="${TEAM}" \
+      --passkey="${PASSKEY}" \
+      --gpu="${ENABLE_GPU}" \
+      --smp="${ENABLE_SMP}" \
+      --power=full \
+      --gui-enabled=false \
+      "${@}"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,12 @@
 #!/bin/bash
 set -e
 
-# if a command was specified, we run that command. E.g. helpful when we do
-# docker run -it <container> /bin/bash
-if [ "${1}" ]
-then
-  exec "$@"
-# otherwise we attempt to run fahclient.
-else
-  /opt/fahclient/FAHClient \
-      --user="${USER}" \
-      --team="${TEAM}" \
-      --passkey="${PASSKEY}" \
-      --gpu="${ENABLE_GPU}" \
-      --smp="${ENABLE_SMP}" \
-      --power=full \
-      --gui-enabled=false \
-      "${@}"
-fi
+/opt/fahclient/FAHClient \
+    --user="${USER}" \
+    --team="${TEAM}" \
+    --passkey="${PASSKEY}" \
+    --gpu="${ENABLE_GPU}" \
+    --smp="${ENABLE_SMP}" \
+    --power=full \
+    --gui-enabled=false \
+    "${@}"


### PR DESCRIPTION
Hello there,

This should fix #1 and allows interactive mode in the entrypoint.sh which can be useful for e.g. debugging. 