### PR TITLE
Fix permissions for work dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:stable-slim
 ARG version="v7.5"
 
 RUN useradd --system folding && \
-    mkdir -p /opt/fahclient && \
+    mkdir -p /opt/fahclient/work && \
     # download and untar
     apt-get update -y && \
     apt-get install -y wget bzip2 && \


### PR DESCRIPTION
I want to put `/opt/fahclient/work` in a volume, to preserve work during restarts.

If I do that today, `/opt/fahclient/work` is mounted with `root:root` ownership, and `folding` user has no permissions to write in it.

According to https://github.com/docker/compose/issues/3270, the workaround is to let `Dockerfile` create the folder in advance and set ownership to it, then Docker will preserve ownership during volume mount.

Per that thread, we _don't_ need to add `VOLUME` as it will actually reset ownership if we put it in a wrong location of `Dockerfile`, and it's optional anyway.

This change makes sure `/opt/fahclient/work` is created in advance, and your code later already handles setting proper permissions recursively on `/opt/fahclient`, so it should be enough to fix the issue.