### PR TITLE
get GPUs.txt to work around bug

### DIFF
--- a/Dockerfile.nvidia
+++ b/Dockerfile.nvidia
@@ -20,6 +20,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get install -y wget bzip2 && \
     wget https://download.foldingathome.org/releases/public/release/fahclient/debian-stable-64bit/${version}/latest.tar.bz2 -O /tmp/fahclient.tar.bz2 && \
     tar -xjf /tmp/fahclient.tar.bz2 -C /opt/fahclient --strip-components=1 && \
+# need GPUs.txt for bug in fahclient 7.6.9
+    wget https://apps.foldingathome.org/GPUs.txt -O /opt/fahclient/GPUs.txt && \
 # fix permissions
     chown -R folding:folding /opt/fahclient && \
 # cleanup


### PR DESCRIPTION
This is annoying, but I fought for a long time to get my GPUs to be recognized with fahclient 7.6.9. There's [apparently a bug](https://foldingforum.org/viewtopic.php?f=106&t=34826#p330083) related to it downloading the `GPUs.txt` file, and this works around it. It'll presumably be fixed in the next release, but in the meantime this made it recognize my GPUs, so probably a good thing to add in the meantime.